### PR TITLE
Prevent mismatched upstream counts during local window rollovers

### DIFF
--- a/internal/limiter/limiter.go
+++ b/internal/limiter/limiter.go
@@ -122,9 +122,9 @@ func (l *Limiter) loop() {
 		case req := <-l.admitCh:
 			l.handleAdmit(req, keys, buckets, regionIndex, &wakeups)
 		case obs := <-l.observeCh:
-			l.handleObservation(obs, keys, buckets, regionIndex, &wakeups)
+			l.handleObservation(obs, keys, regionIndex, &wakeups)
 			// Drain all pending observations before re-entering select.
-			l.drainObservations(keys, buckets, regionIndex, &wakeups)
+			l.drainObservations(keys, regionIndex, &wakeups)
 		case <-timer.C:
 			now := l.cfg.Clock.Now()
 			for len(wakeups) > 0 {
@@ -198,7 +198,6 @@ func (l *Limiter) handleAdmit(
 func (l *Limiter) handleObservation(
 	obs Observation,
 	keys []keyState,
-	buckets map[string]*bucketQueue,
 	regionIndex map[string][]*bucketQueue,
 	wakeups *wakeHeap,
 ) {
@@ -226,7 +225,7 @@ func (l *Limiter) handleObservation(
 	methodLimits := parseRateHeader(obs.Header.Get("X-Method-Rate-Limit"), obs.Header.Get("X-Method-Rate-Limit-Count"))
 
 	key.app(obs.Region, now, l.cfg.AdditionalWindow).apply(appLimits, retryAfter, applyAppRetry, now, l.cfg.AdditionalWindow)
-	key.method(obs.Bucket, now, l.cfg.AdditionalWindow).apply(methodLimits, retryAfter, applyMethodRetry, now, l.cfg.AdditionalWindow)
+	key.method(obs.Bucket).apply(methodLimits, retryAfter, applyMethodRetry, now, l.cfg.AdditionalWindow)
 
 	// An app-limit update can unblock or block multiple buckets in the same region.
 	for _, bucket := range regionIndex[obs.Region] {
@@ -236,14 +235,13 @@ func (l *Limiter) handleObservation(
 
 func (l *Limiter) drainObservations(
 	keys []keyState,
-	buckets map[string]*bucketQueue,
 	regionIndex map[string][]*bucketQueue,
 	wakeups *wakeHeap,
 ) {
 	for {
 		select {
 		case obs := <-l.observeCh:
-			l.handleObservation(obs, keys, buckets, regionIndex, wakeups)
+			l.handleObservation(obs, keys, regionIndex, wakeups)
 		default:
 			return
 		}
@@ -294,7 +292,7 @@ func (l *Limiter) dispatch(bucket *bucketQueue, keys []keyState, wakeups *wakeHe
 		} else {
 			key := &keys[keyIndex]
 			if !key.app(bucket.region, now, l.cfg.AdditionalWindow).consume(now, req.admission.BudgetID) ||
-				!key.method(bucket.bucket, now, l.cfg.AdditionalWindow).consume(now, req.admission.BudgetID) {
+				!key.method(bucket.bucket).consume(now, req.admission.BudgetID) {
 				cannotServe = true
 				wakeAt = now.Add(5 * time.Millisecond)
 			}
@@ -352,7 +350,7 @@ func (l *Limiter) pickKey(
 
 		key := &keys[i]
 		appAt := key.app(region, now, l.cfg.AdditionalWindow).nextAllowed(now, budgetID, budgetShare, bypassPacing)
-		methodAt := key.method(bucket, now, l.cfg.AdditionalWindow).nextAllowed(now, budgetID, budgetShare, bypassPacing)
+		methodAt := key.method(bucket).nextAllowed(now, budgetID, budgetShare, bypassPacing)
 		readyAt := appAt
 		if methodAt.After(readyAt) {
 			readyAt = methodAt

--- a/internal/limiter/state.go
+++ b/internal/limiter/state.go
@@ -8,10 +8,17 @@ import (
 const defaultBudgetID = "default"
 
 type limitWindow struct {
-	limit   int
-	used    int
-	window  time.Duration
-	resetAt time.Time
+	limit        int
+	used         int
+	window       time.Duration
+	resetAt      time.Time
+	locallyReset bool
+}
+
+func (w *limitWindow) rollover(now time.Time) {
+	w.used = 0
+	w.resetAt = now.Add(w.window)
+	w.locallyReset = true
 }
 
 type rateState struct {
@@ -46,8 +53,7 @@ func (s *rateState) nextAllowed(now time.Time, budgetID string, share float64, b
 	for i := range s.windows {
 		w := &s.windows[i]
 		if !w.resetAt.After(now) {
-			w.used = 0
-			w.resetAt = now.Add(w.window)
+			w.rollover(now)
 		}
 		if w.used >= w.limit && w.resetAt.After(next) {
 			next = w.resetAt
@@ -90,8 +96,7 @@ func (s *rateState) consume(now time.Time, budgetID string) bool {
 	for i := range s.windows {
 		w := &s.windows[i]
 		if !w.resetAt.After(now) {
-			w.used = 0
-			w.resetAt = now.Add(w.window)
+			w.rollover(now)
 		}
 		if w.used >= w.limit {
 			return false
@@ -142,11 +147,17 @@ func (s *rateState) apply(
 				seenCount = true
 			}
 
-			if old, ok := existing[next.window]; ok && old.resetAt.After(now) {
-				if old.used > next.used {
-					next.used = old.used
+			if old, ok := existing[next.window]; ok {
+				if !old.resetAt.After(now) {
+					next.rollover(now)
+				} else {
+					// After a local rollover, upstream counts belong to a differently aligned window.
+					if old.locallyReset || old.used > next.used {
+						next.used = old.used
+					}
+					next.resetAt = old.resetAt
+					next.locallyReset = old.locallyReset
 				}
-				next.resetAt = old.resetAt
 			}
 
 			updated = append(updated, next)
@@ -253,7 +264,7 @@ func (k *keyState) app(region string, now time.Time, additionalWindow time.Durat
 	return state
 }
 
-func (k *keyState) method(bucket string, now time.Time, additionalWindow time.Duration) *rateState {
+func (k *keyState) method(bucket string) *rateState {
 	state, ok := k.methodByBucket[bucket]
 	if ok {
 		return state

--- a/internal/limiter/state_test.go
+++ b/internal/limiter/state_test.go
@@ -145,4 +145,66 @@ func TestRateStateConsumeAndApply(t *testing.T) {
 			t.Fatal("default lastGranted is set, want only worker pacing updated")
 		}
 	})
+
+	t.Run("active local window ignores count from differently aligned upstream window", func(t *testing.T) {
+		t.Parallel()
+
+		additionalWindow := 150 * time.Millisecond
+		state := rateState{}
+		state.apply(
+			[]parsedWindow{{limit: 1500, count: 1, window: 10 * time.Second}},
+			nil,
+			false,
+			now,
+			additionalWindow,
+		)
+
+		resetAt := now.Add(10*time.Second + additionalWindow)
+		nowAfterReset := resetAt.Add(time.Millisecond)
+		if !state.consume(nowAfterReset, "") {
+			t.Fatal("consume() after local reset = false, want true")
+		}
+
+		state.apply(
+			[]parsedWindow{{limit: 1500, count: 23, window: 10 * time.Second}},
+			nil,
+			false,
+			nowAfterReset,
+			additionalWindow,
+		)
+
+		if got, want := state.windows[0].used, 1; got != want {
+			t.Fatalf("used after apply = %d, want locally consumed %d", got, want)
+		}
+	})
+
+	t.Run("observation rolls expired window without importing upstream count", func(t *testing.T) {
+		t.Parallel()
+
+		additionalWindow := 150 * time.Millisecond
+		state := rateState{}
+		state.apply(
+			[]parsedWindow{{limit: 1500, count: 1, window: 10 * time.Second}},
+			nil,
+			false,
+			now,
+			additionalWindow,
+		)
+
+		nowAfterReset := now.Add(10*time.Second + additionalWindow + time.Millisecond)
+		state.apply(
+			[]parsedWindow{{limit: 1500, count: 23, window: 10 * time.Second}},
+			nil,
+			false,
+			nowAfterReset,
+			additionalWindow,
+		)
+
+		if got := state.windows[0].used; got != 0 {
+			t.Fatalf("used after rollover = %d, want 0", got)
+		}
+		if !state.windows[0].locallyReset {
+			t.Fatal("locallyReset after rollover = false, want true")
+		}
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rate limiting window management to better handle local and upstream observation synchronization and alignment.
  * Simplified rate limiting logic for cleaner method-based pacing calculations.

* **Tests**
  * Added test coverage for local window behavior and upstream observation rollover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->